### PR TITLE
Only search for open JIRA tickets

### DIFF
--- a/jfa/list_issues.py
+++ b/jfa/list_issues.py
@@ -142,7 +142,7 @@ def get_search_jql(query_str: str) -> str:
         )
     else:
         return get_project_filter() + interpolate_variables_into_jql(
-            'summary ~ "{query_str}*" ORDER BY lastViewed DESC',
+            'summary ~ "{query_str}*" AND status != "Closed" ORDER BY lastViewed DESC',
             query_str=query_str,
         )
 


### PR DESCRIPTION
I find this helpful because if I am searching for a card, there are so many closed cards, I usually can't find the card. 

This only affects the searching, if I have the exact key, it doesn't matter if the card is open or closed 🔥

This also could be a user preference we could add