### PR TITLE
Fix Unicode normalization for non-ASCII search queries

### DIFF
--- a/jfa/list_issues.py
+++ b/jfa/list_issues.py
@@ -5,6 +5,7 @@ import os
 import os.path
 import re
 import sys
+import unicodedata
 from urllib.parse import urlparse
 
 import jfa.core as core
@@ -167,7 +168,7 @@ def get_result_list(query_str: str) -> list[Result]:
 def main(query_str: str) -> None:
     try:
         # Normalize query string by stripping leading/trailing whitespace
-        query_str = query_str.strip()
+        query_str = unicodedata.normalize('NFC', query_str.strip())
 
         # If query string appears to be a URL to a Jira issue, convert it to an
         # issue key, then search using that issue key


### PR DESCRIPTION
Korean text searches weren't working properly due to Unicode normalization differences between macOS input (NFD format) and expected search format (NFC format). Added `unicodedata.normalize('NFC', ...)` to the search query processing in `main()` function to fix this issue.